### PR TITLE
Firmware code for Simple Sampler

### DIFF
--- a/SimpleSampler/firmwares/PTAL/core/Debouncer.h
+++ b/SimpleSampler/firmwares/PTAL/core/Debouncer.h
@@ -1,0 +1,101 @@
+// Copyright 2024 Cedric Stoquer.
+//
+// Author: Cedric Stoquer
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// -----------------------------------------------------------------------------
+//
+// Digital input debouncer
+
+
+#ifndef _PTAL_Debouncer_h
+#define _PTAL_Debouncer_h
+
+#include "daisy_core.h"
+#include "per/gpio.h"
+
+namespace ptal {
+
+class Debouncer {
+  private:
+    dsy_gpio _pin;
+    int      _state;
+    int      _debounceCounter;
+    bool     _isDebouncing;
+    int      _debounceLength;
+    bool     _inverted;
+
+  public:
+
+    bool risingEdge;
+    bool fallingEdge;
+    bool value;
+
+    //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+    void Init (
+      dsy_gpio_pin  pin,
+      int           debounceLength, // = 8,
+      bool          invertedInput, //  = true,
+      dsy_gpio_pull pull //            = DSY_GPIO_PULLUP
+    ) {
+      _pin.pin  = pin;
+      _pin.mode = DSY_GPIO_MODE_INPUT;
+      _pin.pull = pull;
+      dsy_gpio_init(&_pin);
+
+      _debounceLength  = debounceLength;
+      _inverted        = invertedInput;
+      _state           = invertedInput ? 1 : 0;
+      _debounceCounter = 0;
+      _isDebouncing    = false;
+      risingEdge       = false;
+      fallingEdge      = false;
+      value            = false;
+    }
+
+    //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+    void ResetEdges () {
+      risingEdge  = false;
+      fallingEdge = false;
+    }
+
+    //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+    void Debounce () {
+      risingEdge  = false;
+      fallingEdge = false;
+
+      int pinValue = dsy_gpio_read(&_pin);
+
+      if (_state != pinValue) {
+        _state = pinValue;
+        _isDebouncing = true;
+        _debounceCounter = 0;
+      } else if (_isDebouncing) {
+        if (++_debounceCounter >= _debounceLength) {
+          _isDebouncing = false;
+          _debounceCounter = 0;
+          value = (pinValue > 0) != _inverted;
+          if (value) {
+            risingEdge = true;
+          } else {
+            fallingEdge = true;
+          }
+        }
+      }
+    }
+};
+
+
+} // namespace ptal
+
+#endif // _PTAL_Debouncer_h

--- a/SimpleSampler/firmwares/PTAL/core/Encoder2.h
+++ b/SimpleSampler/firmwares/PTAL/core/Encoder2.h
@@ -1,0 +1,161 @@
+// Copyright 2024 Cedric Stoquer.
+//
+// Author: Cedric Stoquer
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// -----------------------------------------------------------------------------
+//
+// Rotary encoder debouncer
+
+
+#ifndef _PTAL_Encoder2_h
+#define _PTAL_Encoder2_h
+
+#include "daisy_core.h"
+#include "per/gpio.h"
+
+using namespace daisy;
+
+namespace ptal {
+
+class Encoder2 {
+private:
+  dsy_gpio _pinA;
+  dsy_gpio _pinB;
+
+  uint8_t  _debounceA;
+  uint8_t  _debounceB;
+  uint32_t _lastUpdate;
+  uint32_t _throttle;
+
+  bool     _hasBounds;
+  bool     _isCircular;
+  int      _min;
+  int      _max;
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  void _enforceBounds () {
+    if (_hasBounds) {
+      if (_isCircular) {
+        if (value < _min) value = _max;
+        if (value > _max) value = _min;
+      } else {
+        if (value < _min) value = _min;
+        if (value > _max) value = _max;
+      }
+    }
+  }
+
+
+public:
+  int  increment;
+  int  value;
+  bool scrolled;
+
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  void Init (dsy_gpio_pin pinA, dsy_gpio_pin pinB, int throttle = 0) {
+    _pinA.pin  = pinA;
+    _pinA.mode = DSY_GPIO_MODE_INPUT;
+    _pinA.pull = DSY_GPIO_PULLUP;
+
+    _pinB.pin  = pinB;
+    _pinB.mode = DSY_GPIO_MODE_INPUT;
+    _pinB.pull = DSY_GPIO_PULLUP;
+
+    dsy_gpio_init(&_pinA);
+    dsy_gpio_init(&_pinB);
+
+    value       = 0;
+    increment   = 0;
+    scrolled    = false;
+    _debounceA  = 0xff;
+    _debounceB  = 0xff;
+    _hasBounds  = false;
+    _isCircular = false;
+    _lastUpdate = 0;
+    _throttle   = throttle;
+  }
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  void ResetScroll (int offset = 0) {
+    value = offset;
+  }
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  void Debounce () {
+    increment = 0;
+    scrolled  = false;
+
+    // Throttle update speed
+    if (_throttle > 0) {
+      uint32_t now = System::GetNow();
+      if(now - _lastUpdate < _throttle) return;
+      _lastUpdate  = now;
+    }
+
+    // Shift Button states to debounce
+    _debounceA = (_debounceA << 1) | dsy_gpio_read(&_pinA);
+    _debounceB = (_debounceB << 1) | dsy_gpio_read(&_pinB);
+
+    // infer increment direction
+    if ((_debounceA & 0x03) == 0x02 && (_debounceB & 0x03) == 0x00) {
+        increment = 1;
+        scrolled  = true;
+    } else if ((_debounceB & 0x03) == 0x02 && (_debounceA & 0x03) == 0x00) {
+        increment = -1;
+        scrolled  = true;
+    }
+    value += increment;
+    _enforceBounds();
+  }
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  void SetBounds (int min, int max) {
+    _hasBounds = true;
+    _min = min;
+    _max = max;
+    _enforceBounds();
+  }
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  void SetBounds (int min, int max, int v) {
+    _hasBounds = true;
+    _min = min;
+    _max = max;
+    value = v;
+    _enforceBounds();
+  }
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  void SetCircular (bool value) {
+    _isCircular = value;
+  }
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  void SetCircularBounds (int min, int max, int v) {
+    SetBounds(min, max, v);
+    _isCircular = true;
+  }
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  void SetValue (int v) {
+    value = v;
+    _enforceBounds();
+  }
+};
+
+
+} // namespace ptal
+
+#endif // _PTAL_Encoder2_h

--- a/SimpleSampler/firmwares/PTAL/core/PwmLed.h
+++ b/SimpleSampler/firmwares/PTAL/core/PwmLed.h
@@ -1,0 +1,396 @@
+// Copyright 2024 Cedric Stoquer.
+//
+// Author: Cedric Stoquer
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// -----------------------------------------------------------------------------
+//
+// Soft-PWM LED driver
+
+
+#ifndef _PTAL_PwmLed_h
+#define _PTAL_PwmLed_h
+
+#include "daisy_core.h"
+#include "per/gpio.h"
+
+
+namespace ptal {
+
+static const int LED_MAX_PWM = 64;
+
+int _pwmLed_globalSpeed;
+
+
+class PwmLed {
+  private:
+
+    enum Mode {
+      MODE_SOLID,
+      MODE_PWM,
+      MODE_BLINK,
+      MODE_BLINK_PWM,
+      MODE_PULSE,
+      MODE_TRIANGLE,
+      MODE_FLASH,
+    };
+
+    struct LedState {
+      Mode mode;
+      bool state;
+      int  pwm;
+      int  speed;
+      int  counter;
+      int  min;
+      int  max;
+      int  direction;
+    };
+
+
+    dsy_gpio _pin;
+    int      _pwmThreshold;     // width of the PWM (64 levels)
+    Mode     _mode;             // animation mode
+    bool     _state;            // hardware state of the LED (ON or OFF)
+    int      _animationSpeed;   // how many update required to increment one frame
+    int      _animationCounter; // counter to control the duration of one frame
+    int      _animationMin;     // min intensity of animation
+    int      _animationMax;     // max intensity of animation
+    int      _lfoDirection;
+    LedState _ledState;
+
+
+
+    //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+    void _updatePwm (int pwmCounter) {
+      bool value = pwmCounter < _pwmThreshold;
+      if (_state == value) return;
+      dsy_gpio_write(&_pin, value);
+      _state = value;
+    }
+
+    //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+    void _setAnimationMinMax (int min, int max) {
+      _animationMin = min < max ? min : max;
+      _animationMax = max > min ? max : min;
+      if (_animationMin < 0) _animationMin = 0;
+      if (_animationMax > LED_MAX_PWM) _animationMax = LED_MAX_PWM;
+    }
+
+    //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+    void _saveState () {
+      _ledState.mode      = _mode;
+      _ledState.state     = _state;
+      _ledState.pwm       = _pwmThreshold;
+      _ledState.speed     = _animationSpeed;
+      _ledState.counter   = _animationCounter;
+      _ledState.min       = _animationMin;
+      _ledState.max       = _animationMax;
+      _ledState.direction = _lfoDirection;
+    }
+
+    //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+    void _restoreState () {
+      if (_ledState.state != _state) dsy_gpio_write(&_pin, _ledState.state);
+      _mode             = _ledState.mode;
+      _state            = _ledState.state;
+      _pwmThreshold     = _ledState.pwm;
+      _animationSpeed   = _ledState.speed;
+      _animationCounter = _ledState.counter;
+      _animationMin     = _ledState.min;
+      _animationMax     = _ledState.max;
+      _lfoDirection     = _ledState.direction;
+    }
+
+
+  public:
+    enum AnimSpeed {
+      SLOW,
+      MID,
+      FAST,
+    };
+
+    //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+    static int GetPwmSize () {
+      return LED_MAX_PWM;
+    }
+
+    //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+    static void SetGlobalSpeed (int value) {
+      _pwmLed_globalSpeed = value;
+    }
+
+    //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+    void Init (dsy_gpio_pin  pin) {
+      _pin.pin  = pin;
+      _pin.mode = DSY_GPIO_MODE_OUTPUT_PP;
+      dsy_gpio_init(&_pin);
+      _mode  = Mode::MODE_SOLID;
+      _state = false;
+      dsy_gpio_write(&_pin, false);
+    }
+
+    //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+    void SetPwm (float value) {
+      int pwmValue = (int)(value * value * (float)LED_MAX_PWM);
+      SetPwm(pwmValue);
+    }
+
+    //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+    void SetPwm (int value) {
+      if (value <= 0)           { SetSolid(false); return; }
+      if (value >= LED_MAX_PWM) { SetSolid(true);  return; }
+
+      if (_mode == Mode::MODE_FLASH) {
+        _ledState.mode    = Mode::MODE_PWM;
+        _ledState.state   = false;
+        _ledState.pwm     = value;
+        _ledState.counter = 0;
+        return;
+      }
+
+      _pwmThreshold = value;
+      _mode = Mode::MODE_PWM;
+    }
+
+    //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+    void SetSolid (bool value) {
+      if (_mode == Mode::MODE_FLASH) {
+        _ledState.mode  = Mode::MODE_SOLID;
+        _ledState.state = value;
+        return;
+      }
+
+      _mode = Mode::MODE_SOLID;
+      if (_state == value) return;
+      _state = value;
+      dsy_gpio_write(&_pin, value);
+    }
+
+    //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+    void SetBlink (AnimSpeed speed = AnimSpeed::MID) {
+      int animationSpeed;
+
+      switch (speed) {
+        case AnimSpeed::SLOW: animationSpeed = 121; break;
+        case AnimSpeed::MID:  animationSpeed =  65; break;
+        case AnimSpeed::FAST: animationSpeed =  32; break;
+      }
+
+      SetBlink(animationSpeed);
+    }
+
+    //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+    void SetBlink (int speed = 64) {
+      speed *= _pwmLed_globalSpeed;
+
+      if (_mode == Mode::MODE_FLASH) {
+        _ledState.mode    = Mode::MODE_BLINK;
+        _ledState.speed   = speed;
+        _ledState.counter = speed;
+        return;
+      }
+
+      _mode = Mode::MODE_BLINK;
+      _animationSpeed   = speed;
+      _animationCounter = speed;
+    }
+
+    //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+    void SetBlinkDim (AnimSpeed speed = AnimSpeed::MID, int min = 0, int max = LED_MAX_PWM) {
+      int animationSpeed;
+
+      switch (speed) {
+        case AnimSpeed::SLOW: animationSpeed = 121 * _pwmLed_globalSpeed; break;
+        case AnimSpeed::MID:  animationSpeed =  65 * _pwmLed_globalSpeed; break;
+        case AnimSpeed::FAST: animationSpeed =  32 * _pwmLed_globalSpeed; break;
+      }
+
+      if (_mode == Mode::MODE_FLASH) {
+        _ledState.mode    = Mode::MODE_BLINK_PWM;
+        _ledState.speed   = animationSpeed;
+        _ledState.counter = animationSpeed;
+        _ledState.pwm     = min < max ? min : max;
+        _ledState.min     = min;
+        _ledState.max     = max;
+        return;
+      }
+
+      _mode = Mode::MODE_BLINK_PWM;
+      _animationSpeed   = animationSpeed;
+      _animationCounter = animationSpeed;
+      _setAnimationMinMax(min, max);
+      _pwmThreshold = min < max ? min : max;
+    }
+
+    //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+    void SetPulse (AnimSpeed speed = AnimSpeed::MID) {
+      int animationSpeed;
+
+      switch (speed) {
+        case AnimSpeed::SLOW: animationSpeed = LED_MAX_PWM * 8; break;
+        case AnimSpeed::MID:  animationSpeed = LED_MAX_PWM * 3;  break;
+        case AnimSpeed::FAST: animationSpeed = LED_MAX_PWM;      break;
+      }
+
+      if (_mode == Mode::MODE_FLASH) {
+        _ledState.mode    = Mode::MODE_PULSE;
+        _ledState.pwm     = LED_MAX_PWM;
+        _ledState.speed   = animationSpeed;
+        _ledState.counter = animationSpeed;
+        return;
+      }
+
+      _mode = Mode::MODE_PULSE;
+      _animationSpeed   = animationSpeed;
+      _animationCounter = animationSpeed;
+      _pwmThreshold     = LED_MAX_PWM;
+    }
+
+    //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+    void SetTriangle (int speed, int min = 0, int max = LED_MAX_PWM) {
+      int animationSpeed = speed * LED_MAX_PWM;
+
+      if (_mode == Mode::MODE_FLASH) {
+        _ledState.mode      = Mode::MODE_TRIANGLE;
+        _ledState.pwm       = min;
+        _ledState.speed     = animationSpeed;
+        _ledState.counter   = animationSpeed;
+        _ledState.min       = min;
+        _ledState.max       = max;
+        _ledState.direction = 1;
+        return;
+      }
+
+      _mode = Mode::MODE_TRIANGLE;
+      _setAnimationMinMax(min, max);
+
+      _animationSpeed   = animationSpeed;
+      _animationCounter = animationSpeed;
+      _pwmThreshold     = _animationMin;
+      _lfoDirection     = 1;
+    }
+
+    //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+    void SetFlash () {
+      _animationMax = 8; // using max to store the flash count
+
+      if (_mode == Mode::MODE_FLASH) {
+        return;
+      }
+
+      _saveState();
+      _mode = Mode::MODE_FLASH;
+      _animationSpeed   = 48 * _pwmLed_globalSpeed;
+      _animationCounter = _animationSpeed;
+    }
+
+    //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+    void Update (int pwmCounter) {
+      switch (_mode) {
+        //--------------------------------------------------------------------------
+        // SOLID: the LED stay ON or OFF. We don't need to update anything
+        case Mode::MODE_SOLID:
+          break;
+
+
+        //--------------------------------------------------------------------------
+        // PWM: dimmed value without animation
+        case Mode::MODE_PWM:
+          _updatePwm(pwmCounter);
+          break;
+
+
+        //--------------------------------------------------------------------------
+        // BLINK: LED blink between ON and OFF
+        case Mode::MODE_BLINK:
+          if (--_animationCounter == 0) {
+            _animationCounter = _animationSpeed;
+            _state = !_state;
+            dsy_gpio_write(&_pin, _state);
+          }
+          break;
+
+
+        //--------------------------------------------------------------------------
+        // BLINK_PWM: LED blink between 2 discrete values
+        case Mode::MODE_BLINK_PWM:
+          if (--_animationCounter == 0) {
+            _animationCounter = _animationSpeed;
+            if (_pwmThreshold <= _animationMin) {
+              _pwmThreshold = _animationMax;
+            } else {
+              _pwmThreshold = _animationMin;
+            }
+          }
+          _updatePwm(pwmCounter);
+          break;
+
+
+        //--------------------------------------------------------------------------
+        // PULSE: A single pulse decaying until it become solid OFF
+        case Mode::MODE_PULSE:
+          if (--_animationCounter == 0) {
+            if (_pwmThreshold <= 1) {
+              // end of pulse: set to a solid OFF state
+              SetSolid(false);
+              return;
+            } else {
+              // dim pulse pwm by one
+              _pwmThreshold -= 1;
+              _animationCounter = _animationSpeed;
+            }
+          }
+          _updatePwm(pwmCounter);
+          break;
+
+
+        //--------------------------------------------------------------------------
+        // TRIANGLE: triangle LFO between 2 values
+        case Mode::MODE_TRIANGLE:
+          if (--_animationCounter == 0) {
+            _animationCounter = _animationSpeed;
+            _pwmThreshold += _lfoDirection;
+            if (_pwmThreshold <= _animationMin) {
+              _lfoDirection = 1;
+            } else if (_pwmThreshold >= _animationMax) {
+              _lfoDirection = -1;
+            }
+          }
+          _updatePwm(pwmCounter);
+          break;
+
+
+        //--------------------------------------------------------------------------
+        // FLASH: blink for a short time then go back to previous animation
+        case Mode::MODE_FLASH:
+          if (--_animationCounter == 0) {
+            if (--_animationMax <= 0) {
+              _restoreState();
+            } else {
+              _animationCounter = _animationSpeed;
+              _state = !_state;
+              dsy_gpio_write(&_pin, _state);
+            }
+          }
+          break;
+
+      }
+
+
+    }
+};
+
+
+} // namespace ptal
+
+#endif // _PTAL_PwmLed_h

--- a/SimpleSampler/firmwares/PTAL/core/Remapper.h
+++ b/SimpleSampler/firmwares/PTAL/core/Remapper.h
@@ -1,0 +1,175 @@
+// Copyright 2024 Cedric Stoquer.
+//
+// Author: Cedric Stoquer
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// -----------------------------------------------------------------------------
+//
+// Analog input manager and value remapper
+
+
+#ifndef _PTAL_Remapper_h
+#define _PTAL_Remapper_h
+
+namespace ptal {
+
+#define REMAPPER_MAX_ZONES_COUNT 8
+#define REMAPPER_RAW_EPSILON 16
+#define REMAPPER_GET_DELTA(a, b) (a < b ? b - a : a - b)
+
+//▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+struct remapperZone {
+    float minX;
+    float maxX;
+    float minY;
+    float maxY;
+    float rangeX;
+    float rangeY;
+    bool  isDeadZone;
+    int   index;
+};
+
+//▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+class Remapper {
+  private:
+    // float _min   = 0.0f;
+    // float _max   = 1.0f;
+    // float _range = 1.0f;
+    remapperZone   _zones[REMAPPER_MAX_ZONES_COUNT];
+    int            _zoneCount = 0;
+    unsigned short _rawInput;
+
+    //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+    void _setZone (int index, float minX, float maxX, float minY, float maxY, bool isDeadZone) {
+      _zones[index].minX       = minX;
+      _zones[index].maxX       = maxX;
+      _zones[index].minY       = minY;
+      _zones[index].maxY       = maxY;
+      _zones[index].isDeadZone = isDeadZone;
+      _zones[index].rangeX     = maxX - minX;
+      _zones[index].rangeY     = maxY - minY;
+      _zones[index].index      = index;
+    }
+
+    //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+    void _updateUpperBounds (remapperZone *zone, float maxX, float maxY) {
+      zone->maxX   = maxX;
+      zone->maxY   = maxY;
+      zone->rangeX = maxX - zone->minX;
+      zone->rangeY = maxY - zone->minY;
+    }
+
+    //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+    void _setValueUsingZone (remapperZone *zone, float x) {
+      isInDeadZone = zone->isDeadZone;
+      zoneIndex    = zone->index;
+      if (zone->isDeadZone) {
+        value = zone->minY; // it is same as maxY
+        return;
+      }
+      value = zone->minY + zone->rangeY * (x - zone->minX) / zone->rangeX;
+    }
+
+    //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+    void _updateValue () {
+      // not initialized
+      // if (_zoneCount == 0) {
+      //   value = raw;
+      //   return;
+      // }
+
+      // only one zone
+      if (_zoneCount == 1) {
+        _setValueUsingZone(&_zones[0], raw);
+        return;
+      }
+
+      // find zone
+      remapperZone* zone = &_zones[0];
+      for (int i = 1; i < _zoneCount; i++) {
+        // if (x >= zone.minX && x <= zone.maxX) break;
+        if (raw <= zone->maxX) break;
+        zone = &_zones[i];
+      }
+
+      // map in this zone
+      _setValueUsingZone(zone, raw);
+    }
+
+
+  public:
+    float value        = 0.0f;
+    float raw          = 0.0f;
+    bool  changed      = false;
+    bool  isInDeadZone = false;
+    int   zoneIndex    = 0;
+
+    //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+    void SetBounds (float min, float max) {
+      _setZone(0, 0.0f, 1.0f, min, max, false);
+      _zoneCount = 1;
+    }
+
+    //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+    void AddDeadZone (float x, float y, float width) {
+      width /= 2;
+      remapperZone* prev = &_zones[_zoneCount - 1];
+      // TODO: check and resolve dead-zones collisions
+      float lo = x - width;
+      float hi = x + width;
+      _setZone(_zoneCount++, lo, hi, y, y, true);
+      _setZone(_zoneCount++, hi, prev->maxX, y, prev->maxY, false);
+      _updateUpperBounds(prev, lo, y);
+    }
+
+    //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+    void AddBreakPoint (float x, float y) {
+      remapperZone* prev = &_zones[_zoneCount - 1];
+      _setZone(_zoneCount++, x, prev->maxX, y, prev->maxY, false);
+      _updateUpperBounds(prev, x, y);
+    }
+
+    //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+    /**
+     * remap an input value in range [0~1] to the bounds of the remaper
+    */
+    void SetRawValue (unsigned short input) {
+      // TODO: add low-pass filter on input to filter noise
+      // _rawInput = (_rawInput * 3.0 + input) / 4.0;
+
+      // Check delta with previous rawInput to check if changed
+      // if (REMAPPER_GET_DELTA(input, _rawInput) < REMAPPER_RAW_EPSILON) {
+      //   return;
+      // }
+
+      _rawInput = input;
+      changed   = true;
+
+      raw = (float) input / 65536.0f;
+
+      _updateValue();
+    }
+
+
+    //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+    float SetValue (float x) {
+      raw = x;
+      _updateValue();
+      return value;
+    }
+};
+
+
+} // namespace ptal
+
+#endif // _PTAL_Remapper_h

--- a/SimpleSampler/firmwares/SimpleSampler/.gitignore
+++ b/SimpleSampler/firmwares/SimpleSampler/.gitignore
@@ -1,0 +1,2 @@
+# ignore build folder
+build

--- a/SimpleSampler/firmwares/SimpleSampler/FilesScanner.h
+++ b/SimpleSampler/firmwares/SimpleSampler/FilesScanner.h
@@ -1,0 +1,176 @@
+#ifndef SimpleSampler_FileScanner_h
+#define SimpleSampler_FileScanner_h
+
+#include <stdio.h>
+#include <string.h>
+#include "daisysp.h"
+#include "daisy_seed.h"
+#include "./Hardware.h"
+#include "./constants.h"
+#include "./wavFormat.h"
+#include "./SampleMetadata.h"
+#include "./MemoryManager.h"
+#include "./SamplePlayer.h"
+#include "./debug.h"
+
+
+#define MAX_CWD_LENGTH 1024
+#define NULL_CHAR '\0'
+
+
+//▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+// NOTA: FIL needs to be declared as static, or defined in global scope
+static FIL file;
+
+
+
+//▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+class FilesScanner {
+private:
+
+  char _cwd[MAX_CWD_LENGTH]; // current working directory path
+  int  _cwdHead;
+  int  _cwdHeadPrev;
+  
+
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  bool _isWavExtention (const char* fileName) {
+    int i = 0;
+
+    // Go to the end of file name
+    while (fileName[i] != NULL_CHAR) ++i;
+    if (i <= 4) return false;
+
+    // Go back 4 characters and check these are equal to ".wav"
+    i -= 4;
+    if (fileName[i] != '.') return false;
+    if (fileName[i + 1] != 'w' && fileName[i + 1] != 'W') return false;
+    if (fileName[i + 2] != 'a' && fileName[i + 2] != 'A') return false;
+    if (fileName[i + 3] != 'v' && fileName[i + 3] != 'V') return false;
+    return true;
+  }
+
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  bool _pushFilePathInCwd (const char* fileName) {
+    if (_cwdHeadPrev != _cwdHead) return false;
+    _cwdHeadPrev = _cwdHead;
+    _cwd[_cwdHead++] = '/'; // NOTE: replacing NULL_CHAR with '/'
+
+    int i = 0;
+
+    while (fileName[i] != NULL_CHAR) {
+      _cwd[_cwdHead++] = fileName[i++];
+      if (_cwdHead > MAX_CWD_LENGTH) {
+        _popCwd();
+        return false;
+      }
+    }
+
+    _cwd[_cwdHead++] = NULL_CHAR;
+
+    return true;
+  }
+
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  void _popCwd () {
+    _cwdHead = _cwdHeadPrev;
+    _cwd[_cwdHead] = NULL_CHAR;
+  }
+
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  bool _loadWavFileToMemory (MemoryManager* memoryManager, SamplePlayer* samplePlayer) {
+    SampleMetadata* sampleMetadata = samplePlayer->GetNextEmptySlot();
+
+    // Read wav header
+    if (!ReadWavMetaData(&file, sampleMetadata)) return false;
+
+    // Check if we still have enough memory to load this sample
+    size_t sampleLength = sampleMetadata->sampleLength;
+    if (!memoryManager->CanLoadSample(sampleLength)) {
+      return false;
+    }
+
+    // Load sample data to SDRAM
+    int16_t* buffer  = memoryManager->GetBufferHead();
+    UINT bytesToRead = sampleLength * BYTE_PER_SAMPLE;
+    UINT bytesRead;
+
+    if (f_read(&file, buffer, bytesToRead, &bytesRead) != FR_OK) {
+      return false;
+    }
+
+    // Check if we read the expected amount of bytes
+    if (bytesToRead != bytesRead) return false;
+
+    // Save buffer, update memory head pointer and confirm sample added
+    sampleMetadata->buffer = buffer;
+    memoryManager->IncrementHeadPointer(sampleLength);
+    samplePlayer->AddSample();
+    return true;
+  }
+
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  bool _loadFile (MemoryManager* memoryManager, SamplePlayer* samplePlayer) {
+    // Open file at current working path
+    if (f_open(&file, _cwd, (FA_OPEN_EXISTING) | (FA_READ)) != FR_OK) {
+      return false;
+    }
+
+    bool success = _loadWavFileToMemory(memoryManager, samplePlayer);
+
+    f_close(&file);
+
+    return success;
+  }
+
+
+public:
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  void Init (Hardware* hardware) {
+    _cwdHead = 0;
+    strcpy(_cwd, hardware->GetSdCardPath()); // NOTE: root path of SD Card is "0:"
+    while (_cwd[_cwdHead] != NULL_CHAR) ++_cwdHead;
+    _cwdHeadPrev = _cwdHead;
+  }
+
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  bool ScanDirectory (MemoryManager* memoryManager, SamplePlayer* samplePlayer) {
+    DIR     directory;
+    FILINFO fileInfo;
+
+
+    if (f_opendir(&directory, _cwd) != FR_OK) {
+      return false;
+    }
+
+    while (true) {
+      if (f_readdir(&directory, &fileInfo) != FR_OK) break; // something went wrong
+      if (fileInfo.fname[0] == NULL_CHAR)            break; // end of directory
+      if (fileInfo.fattrib & (AM_HID))      continue; // skip hidden files
+      if (fileInfo.fattrib & (AM_DIR))      continue; // skip directories
+      if (!_isWavExtention(fileInfo.fname)) continue; // skip non-wav files
+
+      // load file
+      if (!_pushFilePathInCwd(fileInfo.fname)) continue;
+      debug.PrintString(_cwd);
+      _loadFile(memoryManager, samplePlayer);
+      _popCwd();
+
+      if (samplePlayer->IsSampleCountMaxed()) break;
+    }
+
+    f_closedir(&directory);
+    return true;
+  }
+
+};
+
+
+#endif // SimpleSampler_FileScanner_h

--- a/SimpleSampler/firmwares/SimpleSampler/Hardware.h
+++ b/SimpleSampler/firmwares/SimpleSampler/Hardware.h
@@ -1,0 +1,134 @@
+#ifndef _SimpleSampler_hardware_h
+#define _SimpleSampler_hardware_h
+
+
+#include <stdio.h>
+#include <string.h>
+#include "daisy_seed.h"
+#include "fatfs.h"
+#include "../PTAL/core/Debouncer.h"
+#include "../PTAL/core/Encoder2.h"
+#include "../PTAL/core/Remapper.h"
+#include "../PTAL/core/PwmLed.h"
+
+
+using namespace daisy;
+
+//▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+// #define USE_POKI
+
+#ifdef USE_POKI
+  #define PIN_CV_IN     17
+  #define PIN_LED       14
+  #define PIN_ENCODER_A 10
+  #define PIN_ENCODER_B 11
+  #define PIN_GATE_PLAY 15
+  #define PIN_GATE_RAND 27
+  #define PIN_GATE_PART 25
+#else
+  #define PIN_CV_IN     15
+  #define PIN_LED       17
+  #define PIN_ENCODER_A 19
+  #define PIN_ENCODER_B 20
+  #define PIN_GATE_PLAY 16
+  #define PIN_GATE_RAND 18
+  #define PIN_GATE_PART 21
+#endif
+
+#define GATE_COUNT 3
+static const int ADC_COUNT = 1;
+static const int LED_PWM_MAX = ptal::PwmLed::GetPwmSize();
+
+//▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+SdmmcHandler   _sdCard;
+FatFSInterface fatFsInterface;
+
+
+//▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+class Hardware {
+private:
+  int _currentGateIndex;
+  int _ledPwmCounter;
+
+public:
+  DaisySeed       daisy;
+  ptal::Debouncer gates[3];
+  ptal::Encoder2  encoder;
+  ptal::Remapper  cvInput;
+  ptal::PwmLed    led;
+
+  ptal::Debouncer *gatePlay = &gates[0];
+  ptal::Debouncer *gateRand = &gates[1];
+  ptal::Debouncer *gatePart = &gates[2];
+
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  void Init () {
+    daisy.Configure(); // NOTA: deprecated. This actually does nothing and can be removed
+    daisy.Init();
+
+    // Initialize analog inputs (ADC)
+    AdcChannelConfig adc[ADC_COUNT];
+    adc[0].InitSingle(daisy.GetPin(PIN_CV_IN));
+    daisy.adc.Init(adc, ADC_COUNT);
+    daisy.adc.Start();
+    cvInput.SetBounds(0.0f, 1.0f);
+
+    // Initialize encoder
+    encoder.Init(daisy.GetPin(PIN_ENCODER_A), daisy.GetPin(PIN_ENCODER_B), 4);
+
+    // Initialize input gates.
+    gates[0].Init(daisy.GetPin(PIN_GATE_PLAY), 30, true, DSY_GPIO_PULLUP);
+    gates[1].Init(daisy.GetPin(PIN_GATE_RAND), 30, true, DSY_GPIO_PULLUP);
+    gates[2].Init(daisy.GetPin(PIN_GATE_PART), 30, true, DSY_GPIO_PULLUP);
+    _currentGateIndex = 0;
+
+    // Initialize LED
+    ptal::PwmLed::SetGlobalSpeed(340);
+    led.Init(daisy.GetPin(PIN_LED));
+    _ledPwmCounter = 0;
+
+    System::Delay(200);
+  }
+
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  void InitSdCard () {
+    // Initialize SD card and file system interface
+    SdmmcHandler::Config sdCardHandlerConfig;
+    sdCardHandlerConfig.Defaults(); // High Speed (50MHz)
+    _sdCard.Init(sdCardHandlerConfig);
+
+    // Links libdaisy i/o to fatfs driver.
+    fatFsInterface.Init(FatFSInterface::Config::MEDIA_SD);
+
+    // Mount SD Card
+    f_mount(&fatFsInterface.GetSDFileSystem(), "/", 1);
+  }
+
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  const char* GetSdCardPath () {
+    return fatFsInterface.GetSDPath();
+  }
+
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  void Update () {
+    encoder.Debounce();
+    cvInput.SetRawValue(daisy.adc.Get(0));
+
+    // LED
+    led.Update(_ledPwmCounter);
+    if (++_ledPwmCounter > LED_PWM_MAX) _ledPwmCounter = 0;
+
+    // Gate inputs: debounce only one per cycle
+    gates[_currentGateIndex].ResetEdges();
+    if (++_currentGateIndex >= GATE_COUNT) _currentGateIndex = 0;
+    gates[_currentGateIndex].Debounce();
+  }
+
+};
+
+
+#endif // _SimpleSampler_hardware_h

--- a/SimpleSampler/firmwares/SimpleSampler/Makefile
+++ b/SimpleSampler/firmwares/SimpleSampler/Makefile
@@ -1,0 +1,16 @@
+# Project Name
+TARGET = SimpleSampler
+
+# Sources
+CPP_SOURCES = SimpleSampler.cpp
+
+# Library Locations
+LIBDAISY_DIR = ../../libDaisy
+DAISYSP_DIR = ../../DaisySP
+
+# Includes FatFS source files within project.
+USE_FATFS = 1
+
+# Core location, and generic makefile.
+SYSTEM_FILES_DIR = $(LIBDAISY_DIR)/core
+include $(SYSTEM_FILES_DIR)/Makefile

--- a/SimpleSampler/firmwares/SimpleSampler/MemoryManager.h
+++ b/SimpleSampler/firmwares/SimpleSampler/MemoryManager.h
@@ -1,0 +1,44 @@
+#ifndef SimpleSampler_MemoryManager_h
+#define SimpleSampler_MemoryManager_h
+
+#include "daisysp.h"
+#include "daisy_seed.h"
+#include "./constants.h"
+
+
+//▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+// NOTA: to use SDRAM, the variable must be defined as a global.
+static int16_t DSY_SDRAM_BSS sampleBuffer[BUFFER_SIZE];
+
+
+//▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+class MemoryManager {
+private:
+  size_t _head;
+
+
+public:
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  void Init () {
+    _head = 0;
+  }
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  bool CanLoadSample (size_t size) {
+    return BUFFER_SIZE - _head > size;
+  }
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  int16_t* GetBufferHead () {
+    return &sampleBuffer[_head];
+  }
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  void IncrementHeadPointer (size_t size) {
+    _head += size;
+  }
+
+};
+
+
+#endif // SimpleSampler_MemoryManager_h

--- a/SimpleSampler/firmwares/SimpleSampler/SampleMetadata.h
+++ b/SimpleSampler/firmwares/SimpleSampler/SampleMetadata.h
@@ -1,0 +1,18 @@
+#ifndef SimpleSampler_SampleMetadata_h
+#define SimpleSampler_SampleMetadata_h
+
+
+#include "daisysp.h"
+#include "daisy_seed.h"
+
+//▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+typedef struct  {
+  size_t   dataStart;     // byte position of the data chunk in wav file
+  size_t   sampleLength;  // sample size (in int16)
+  int16_t* buffer;        // pointer to this sample's buffer in SDRAM
+} SampleMetadata;
+
+
+//▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+#endif // SimpleSampler_SampleMetadata_h
+

--- a/SimpleSampler/firmwares/SimpleSampler/SamplePlayer.h
+++ b/SimpleSampler/firmwares/SimpleSampler/SamplePlayer.h
@@ -1,0 +1,118 @@
+#ifndef SimpleSampler_SamplePlayer_h
+#define SimpleSampler_SamplePlayer_h
+
+#include "daisysp.h"
+#include "daisy_seed.h"
+#include "./constants.h"
+#include "./SampleMetadata.h"
+#include "./debug.h"
+
+
+
+//▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+class SamplePlayer {
+private:
+  SampleMetadata  _samples[MAX_SAMPLES_COUNT];
+  SampleMetadata* _currentSample;
+  size_t          _currentSampleIndex;
+  size_t          _samplesCount;
+  bool            _isPlaying;
+  double          _head;
+  double          _increment;
+
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  void _updateCurrentSample () {
+    _currentSample = &_samples[_currentSampleIndex];
+  }
+
+
+
+public:
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  void Init () {
+    _samplesCount       = 0;
+    _currentSampleIndex = 0;
+    _isPlaying          = false;
+    _increment          = 1.0;
+  }
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  SampleMetadata* GetNextEmptySlot () {
+    return &_samples[_samplesCount];
+  }
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  void AddSample () {
+    _samplesCount += 1;
+  }
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  bool IsSampleCountMaxed () {
+    return _samplesCount >= MAX_SAMPLES_COUNT;
+  }
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  void NextSample () {
+    if (++_currentSampleIndex >= _samplesCount) {
+      _currentSampleIndex = 0;
+    }
+  }
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  void PrevSample () {
+    if (_samplesCount == 0) return;
+    if (_currentSampleIndex == 0) {
+      _currentSampleIndex = _samplesCount - 1;
+    } else {
+      _currentSampleIndex -= 1;
+    }
+  }
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  void TriggerSample () {
+    if (_samplesCount == 0) return;
+    _updateCurrentSample();
+    _head      = 0.0;
+    _isPlaying = true;
+  }
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  void SetSpeed (float speed) {
+    _increment = speed;
+  }
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  bool IsPlaying () {
+    return _isPlaying;
+  }
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  void ProcessBlock (
+    float* outputL,
+    float* outputR,
+    size_t size
+  ) {
+    if (!_isPlaying) return; // not sample playing
+    if (_samplesCount == 0) return; // no sample loaded in memory
+
+    for (size_t i = 0; i < size; ++i) {
+      // No interpolation
+      size_t head = (size_t)(_head);
+      float output = s162f(_currentSample->buffer[head]);
+
+      outputL[i] = output;
+      outputR[i] = output;
+
+      _head += _increment;
+      if (_head >= _currentSample->sampleLength) {
+        _isPlaying = false;
+        break;
+      }
+    }
+  }
+
+};
+
+
+#endif // SimpleSampler_SamplePlayer_h

--- a/SimpleSampler/firmwares/SimpleSampler/SimpleSampler.cpp
+++ b/SimpleSampler/firmwares/SimpleSampler/SimpleSampler.cpp
@@ -1,0 +1,76 @@
+#include "daisysp.h"
+#include "daisy_seed.h"
+#include "./Hardware.h"
+#include "./MemoryManager.h"
+#include "./SamplePlayer.h"
+#include "./FilesScanner.h"
+#include "./debug.h"
+#include "./constants.h"
+
+
+using namespace daisy;
+using namespace daisysp;
+
+
+//▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+Hardware      hardware;
+MemoryManager memoryManager;
+SamplePlayer  samplePlayer;
+FilesScanner  filesScanner;
+
+
+
+//▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+static void AudioCallback (
+  daisy::AudioHandle::InputBuffer  in,
+  daisy::AudioHandle::OutputBuffer out,
+  size_t size) {
+
+  // Clear buffer
+  memset(out[0], 0, size * sizeof(float));
+  memset(out[1], 0, size * sizeof(float));
+
+  // Process sample player
+  samplePlayer.ProcessBlock(out[0], out[1], size);
+}
+
+
+//▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+int main (void) {
+  // initializations
+  hardware.Init();
+  debug.Init(&hardware);
+  hardware.InitSdCard();
+  memoryManager.Init();
+  samplePlayer.Init();
+  filesScanner.Init(&hardware);
+  filesScanner.ScanDirectory(&memoryManager, &samplePlayer);
+
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  // Setup audio callback
+  hardware.daisy.SetAudioSampleRate(SaiHandle::Config::SampleRate::SAI_48KHZ);
+  hardware.daisy.SetAudioBlockSize(AUDIO_BLOCK_SIZE);
+  hardware.daisy.StartAudio(AudioCallback);
+
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  while (true) {
+    hardware.Update();
+
+    if (hardware.cvInput.changed) {
+      samplePlayer.SetSpeed(0.5f + hardware.cvInput.value * 1.5f);
+    }
+    
+    if (hardware.encoder.scrolled) {
+      if (hardware.encoder.increment ==  1) samplePlayer.NextSample();
+      if (hardware.encoder.increment == -1) samplePlayer.PrevSample();
+    }
+
+    if (hardware.gatePlay->risingEdge) samplePlayer.TriggerSample();
+
+    // TODO: gateRand, gatePart
+
+    hardware.led.SetSolid(samplePlayer.IsPlaying());
+  }
+}

--- a/SimpleSampler/firmwares/SimpleSampler/constants.h
+++ b/SimpleSampler/firmwares/SimpleSampler/constants.h
@@ -1,0 +1,19 @@
+#ifndef SimpleSampler_constants_h
+#define SimpleSampler_constants_h
+
+
+//▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+#define MAX_MEMORY       (64 * (1 << 20)) // 64 MB of SDRAM
+#define SAMPLE_SIZE      2 // 2 bytes per sample (int16_t)
+#define BUFFER_SIZE      (MAX_MEMORY / SAMPLE_SIZE)
+#define SAMPLE_RATE      48000 // allowed values: 8k, 16k, 32k, 48k, 96k
+#define AUDIO_BLOCK_SIZE 16    // Block size can be any number up to 256
+
+
+//▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+#define MAX_SAMPLES_COUNT 32
+#define ALLOW_DEBUG false
+
+
+
+#endif // SimpleSampler_constants_h

--- a/SimpleSampler/firmwares/SimpleSampler/debug.h
+++ b/SimpleSampler/firmwares/SimpleSampler/debug.h
@@ -1,0 +1,52 @@
+#ifndef SimpleSampler_debug_h
+#define SimpleSampler_debug_h
+
+
+#include "./constants.h"
+#include "./Hardware.h"
+
+
+//▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+class Debug {
+private:
+  Hardware* _hardware;
+
+
+public:
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  void Init (Hardware* hardware) {
+    _hardware = hardware;
+
+    // NOTE: This call is blocking. Program execution will stop until Daisy receive
+    //   an acknowledgement signal from serial port. We need Daisy to be connected
+    //   to a computer via USB, and a serial monitor program running on that computer
+    //   -> On linux and MacOS, we can use the "screen" command in a terminal
+    //   -> On Windows, we need a dedicated program, like Arduino IDE or TTY
+    if (ALLOW_DEBUG) _hardware->daisy.StartLog(true);
+  }
+
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  void PrintString (const char* str) {
+    if (ALLOW_DEBUG) _hardware->daisy.PrintLine(str);
+  }
+
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  void PrintInt (const int value) {
+    if (ALLOW_DEBUG) _hardware->daisy.PrintLine("%d", value);
+  }
+
+
+  //▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+  void PrintFloat (const float value) {
+    if (ALLOW_DEBUG) _hardware->daisy.PrintLine("" FLT_FMT(3), FLT_VAR(3, value));
+  }
+};
+
+
+Debug debug;
+
+
+//▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+#endif // SimpleSampler_debug_h

--- a/SimpleSampler/firmwares/SimpleSampler/wavFormat.h
+++ b/SimpleSampler/firmwares/SimpleSampler/wavFormat.h
@@ -1,0 +1,87 @@
+#ifndef SimpleSampler_wavFormat_h
+#define SimpleSampler_wavFormat_h
+
+
+#include "fatfs.h"
+#include "./SampleMetadata.h"
+
+
+//▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+/*
+Header format for wave files.
+
+For more infos about the wave file format:
+http://soundfile.sapp.org/doc/WaveFormat/
+
+byteRate         == sampleRate * nChannels * bitsPerSample / 8
+blockAlign       == nChannels * BitsPerSample / 8
+                               The number of bytes for one sample including
+                               all channels.
+BitsPerSample    8 bits = 8, 16 bits = 16, etc.
+
+*/
+
+
+#define FMT_SIZE 16 // NOTE: For our purpose, it's alway 16. More means extended
+#define BYTE_PER_SAMPLE 2 // we only support 16 bits audio
+
+
+//▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+// NOTA: IDs are big-endian encoded (i.e. string is reversed)
+#define CHUNK_ID_RIFF 0x46464952 // RIFF
+#define CHUNK_ID_WAVE 0x45564157 // WAVE
+#define CHUNK_ID_fmt  0x20746D66 // fmt█
+#define CHUNK_ID_data 0x61746164 // data
+#define PCM_AUDIO     0x0001
+
+
+//▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+typedef struct {
+  uint32_t RIFF;          // "R I F F"
+  uint32_t fileSize;      // file size, minus 8 bytes (the first 2 fields)
+  uint32_t WAVE;          // "W A V E"
+  uint32_t FMT;           // "f t m █"
+  uint32_t fmtChunkSize;  // fmt chunk size
+  uint16_t audioFormat;   // needs to be PCM
+  uint16_t nChannels;     // number of channels
+  uint32_t sampleRate;    // sampleRate, in Hz
+  uint32_t byteRate;      // byteRate = sampleRate * nChannels * bitsPerSample/8
+  uint16_t blockAlign;    // blockAlign = nChannels * bitsPerSample/8
+  uint16_t bitsPerSample; // bit per sample, usually 16
+  uint32_t DATA;          // "d a t a"
+  uint32_t dataChunkSize; // data chunk size, in byte
+} RiffChunk;
+
+
+
+//▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+extern bool ReadWavMetaData (FIL* file, SampleMetadata* sampleMetadata) {
+  RiffChunk riffChunk;
+  UINT      bytesRead;
+
+
+  // Read RIFF chunk
+  if (f_read(file, (void *)&riffChunk, sizeof(RiffChunk), &bytesRead) != FR_OK) {
+    return false;
+  }
+
+  // Ensure RIFF format is correct and supported (PCM, 16 bits, mono)
+  if (riffChunk.RIFF != CHUNK_ID_RIFF)    return false;
+  if (riffChunk.WAVE != CHUNK_ID_WAVE)    return false;
+  if (riffChunk.FMT  != CHUNK_ID_fmt)     return false;
+  if (riffChunk.fmtChunkSize != FMT_SIZE) return false;
+  if (riffChunk.audioFormat != PCM_AUDIO) return false;
+  if (riffChunk.nChannels != 1)           return false;
+  if (riffChunk.bitsPerSample != 16)      return false;
+  if (riffChunk.DATA != CHUNK_ID_data)    return false;
+
+  // Store DATA chunk position and sample length
+  sampleMetadata->dataStart    = file->fptr;
+  sampleMetadata->sampleLength = riffChunk.dataChunkSize / BYTE_PER_SAMPLE;
+
+  return true;
+}
+
+
+//▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
+#endif // SimpleSampler_wavFormat_h


### PR DESCRIPTION
Sorry, this pull request got bigger than expected.

- files in `firmware/PTAL/core` are my "hardware" components I developed for my Daisy Seed projects. I originally intended to only use the basic components provided by Electro-Smith. But I couldn't make them behave like I wanted (especially the digital inputs debouncing).So I gave-up and copy-pasted these files in here.
- `firmwares/SimpleSampler` is the actual firmware for the Simple Sampler.

This firmware have the following features:
- At startup, scan SD Card for all`.wav` files, and load them into memory, if the format is supported.
- Only supports MONO, 16bits, PCM wave files.
- Trigger sample playback with the "TRIG" gate input / push button
- Change current sample with the rotary encoder
- Change playback speed with the CV input / potentiometer
- LED lights up when sample is playing
- Max 32 samples can be loaded in memory (this number can be changed in `constants.h`)

I tested the code on a different module, with different pin configuration. So you might want to check `SimpleSampler/Hardware.h`, and verify that the pin IDs are correct.

Arguably, the most complex part of this code is the logic related to scanning the SD Card content and loading wav files into memory.

## TODO & Improvements

- I didn't used the "PART" switch nor "RAND" input. The gate inputs are configured, just not used yet.
- I didn't implemented interpolation. So samples sound a bit lo-fi when pitched down.
- I experienced some clic noises at the end of some samples playback. There might be a bug somewhere.
